### PR TITLE
Opt out of `openssl` for `reqwest`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ license = "MIT"
 edition = "2021"
 rust-version = "1.70"
 
+[features]
+default = ["reqwest/rustls-tls-webpki-roots"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
@@ -32,7 +35,7 @@ parking_lot = "0.12"
 pem = { package = "pem-rfc7468", version = "0.7" }
 pkcs8 = "0.10"
 rand = "0.8"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = { version = "0.10.6", features = ["oid"] }


### PR DESCRIPTION
### Description

I noticed this library depends on `openssl` via the default features of `reqwest`. This PR uses `rustls` with `webpki-roots` by default.

### Testing

I ran one of the examples that makes an https request and it appeared to work.