### PR TITLE
Preserve order of domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Ensure domains remain in original order throughout processing.
+
 ## 0.1.0
 
 - Initial release.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ parking_lot = "0.12"
 pem = { package = "pem-rfc7468", version = "0.7" }
 pkcs8 = "0.10"
 rand = "0.8"
-reqwest = { version = "0.11", features = ["json"], default-features = false }
+reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = { version = "0.10.6", features = ["oid"] }

--- a/src/acc/mod.rs
+++ b/src/acc/mod.rs
@@ -77,14 +77,13 @@ impl Account {
         primary_name: &str,
         alt_names: &[&str],
     ) -> eyre::Result<NewOrder> {
-        let domains = iter::once(&primary_name)
-            .chain(alt_names)
-            .collect::<HashSet<_>>();
-
-        let identifiers = domains
-            .into_iter()
-            .map(|&domain| api::Identifier::dns(domain))
-            .collect();
+        let mut identifiers = Vec::new();
+        let mut dedup = HashSet::new();
+        for domain in iter::once(primary_name).chain(alt_names.iter().copied()) {
+            if dedup.insert(domain) {
+                identifiers.push(api::Identifier::dns(domain));
+            }
+        }
 
         let order = api::Order::from_identifiers(identifiers);
 

--- a/src/acc/mod.rs
+++ b/src/acc/mod.rs
@@ -93,7 +93,8 @@ impl Account {
         let order_url = req_expect_header(&res, "location")?;
         let api_order = res.json::<api::Order>().await?;
 
-        let order = Order::new(&self.inner, api_order, order_url);
+        let mut order = Order::new(&self.inner, order, order_url);
+        order.api_order.overwrite(api_order)?;
         Ok(NewOrder { order })
     }
 
@@ -166,6 +167,6 @@ mod tests {
             .await
             .unwrap();
 
-        let _order = acc.new_order("acmetest.example.com", &[]).await.unwrap();
+        let _order = acc.new_order("acme-test.example.com", &[]).await.unwrap();
     }
 }

--- a/src/acc/mod.rs
+++ b/src/acc/mod.rs
@@ -78,9 +78,12 @@ impl Account {
         alt_names: &[&str],
     ) -> eyre::Result<NewOrder> {
         let mut identifiers = Vec::new();
-        let mut dedup = HashSet::new();
+        let mut domain_set = HashSet::new();
+
         for domain in iter::once(primary_name).chain(alt_names.iter().copied()) {
-            if dedup.insert(domain) {
+            // de-duplicate identifiers list
+            if domain_set.insert(domain) {
+                // domain set did not contain `domain`
                 identifiers.push(api::Identifier::dns(domain));
             }
         }

--- a/src/api/order.rs
+++ b/src/api/order.rs
@@ -87,10 +87,10 @@ impl Order {
             .collect()
     }
 
-    // Let's Encrypt was observed to return domains in alternate order which
-    // may flip primary with SAN(s).
-    //
-    // This overwrites self without changing the order of the domains.
+    /// Let's Encrypt was observed to return domains in alternate order which may flip primary with
+    /// SAN(s).
+    ///
+    /// This overwrites self without changing the order of the domains.
     pub(crate) fn overwrite(&mut self, mut from_api: Self) -> eyre::Result<()> {
         // Make sure the lists are the same.
         if from_api.identifiers.len() != self.identifiers.len()
@@ -105,9 +105,11 @@ impl Order {
                 from_api.identifiers
             ));
         }
+
         // Then preserve the original order.
         from_api.identifiers = std::mem::take(&mut self.identifiers);
         *self = from_api;
+
         Ok(())
     }
 }

--- a/src/order/auth.rs
+++ b/src/order/auth.rs
@@ -342,7 +342,7 @@ mod tests {
             .register_account(Some(vec!["mailto:foo@bar.com".to_owned()]))
             .await
             .unwrap();
-        let ord = acc.new_order("acmetest.example.com", &[]).await.unwrap();
+        let ord = acc.new_order("acme-test.example.com", &[]).await.unwrap();
         let authz = ord.authorizations().await.unwrap();
         assert!(authz.len() == 1);
         let auth = &authz[0];

--- a/src/order/mod.rs
+++ b/src/order/mod.rs
@@ -225,7 +225,7 @@ impl CsrOrder {
         // wait for the status to not be processing:
         // valid -> cert is issued
         // invalid -> the whole thing is off
-        let order = poll_order_finalization(&inner, order_url, interval).await?;
+        let order = poll_order_finalization(inner, order_url, interval).await?;
 
         if !matches!(order.api_order.status, Some(api::OrderStatus::Valid)) {
             return Err(eyre::eyre!(

--- a/src/test.rs
+++ b/src/test.rs
@@ -95,7 +95,7 @@ fn post_new_order(url: &str) -> Response<Body> {
     "identifiers": [
         {
         "type": "dns",
-        "value": "acmetest.example.com"
+        "value": "acme-test.example.com"
         }
     ],
     "authorizations": [
@@ -122,7 +122,7 @@ fn post_get_order(url: &str) -> Response<Body> {
     "identifiers": [
         {
         "type": "dns",
-        "value": "acmetest.example.com"
+        "value": "acme-test.example.com"
         }
     ],
     "authorizations": [


### PR DESCRIPTION
Replaces `HashSet` with `Vec` to preserve order of domains, such that primary name remains first.

(I noticed one of my aliases was used as the primary for my certificate)

On top of #2 for my own convenience.

Fixes #4