### PR TITLE
use shared Rust Just module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716077176,
-        "narHash": "sha256-CJLStpZHEVZ+fgXG3H61R97KzQePkdNXpnhkDBtHUec=",
+        "lastModified": 1785501466,
+        "narHash": "sha256-EmBn1w7+V9l1P4XqFLSZDVOxMtMIIGxUrJawlrvaO5U=",
         "owner": "x52dev",
         "repo": "nix",
-        "rev": "4afdfa74f1bef9a7e2e99498c47a25b0753a43e0",
+        "rev": "7f726782d3870c1d11a9480ebeb9a34a693d4a17",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,17 +11,14 @@
 
   outputs = inputs @ { flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ inputs.x52.flakeModules.default ];
+
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      perSystem = { pkgs, config, inputs', system, lib, ... }:
-        let
-          x52just = inputs'.x52.packages.x52-just;
-        in
+      perSystem = { pkgs, config, system, lib, ... }:
         {
           formatter = pkgs.nixpkgs-fmt;
 
           devShells.default = pkgs.mkShell {
-            buildInputs = [ x52just ];
-
             packages = [
               config.formatter
               pkgs.cargo-shear
@@ -33,10 +30,7 @@
               pkgs.pkgsBuildHost.libiconv
             ];
 
-            shellHook = ''
-              mkdir -p .toolchain
-              cp ${x52just}/*.just .toolchain/
-            '';
+            shellHook = config.x52.justRust.shellHook;
           };
         };
     };


### PR DESCRIPTION
## Summary

- import the shared Rust Just flake-parts module
- replace the local `.toolchain` copy hook with `config.x52.justRust.shellHook`
- retain the project-selected `pkgs.mkShell` and `pkgs.just`

## Why

The project uses `rust.just` from `x52dev/nix`. The shared module creates the same local import path without the local package and copy plumbing.

## Validation

- `nix develop -c just --list`
- verified `.toolchain/rust.just` is a symlink
- `nix flake check --no-build`
- `nix develop -c just check` (stops on the existing Taplo formatting failure in `Cargo.toml`; this PR does not change that file)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment setup to use the integrated Rust tooling configuration.
  * Simplified shell initialization by removing manual setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->