### PR TITLE
fix(ci): downgrade actix-server for MSRV

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ downgrade-for-msrv:
     cargo {{ toolchain }} update -p=time --precise=0.3.45 # next ver: 1.88.0
     cargo {{ toolchain }} update -p=actix-web --precise=4.12.0 # next ver: 1.88.0
     cargo {{ toolchain }} update -p=actix-http --precise=3.11.2 # next ver: 1.88.0
+    cargo {{ toolchain }} update -p=actix-server --precise=2.6.0 # next ver: 1.88.0
 
 # Check project
 check:


### PR DESCRIPTION
## Summary

- Pin `actix-server` to `2.6.0` in the existing `downgrade-for-msrv` recipe.

## Why

The MSRV job for #331 uses Rust 1.85, but `actix-server 2.7.0` requires Rust 1.88. The repository already downgrades other dependencies that require Rust 1.88 during MSRV checks; this adds the missing `actix-server` pin.

## Validation

- `nix develop -c just toolchain=+1.85.0 downgrade-for-msrv` passed.
- `nix develop -c just --unstable --fmt --check` passed.
- `nix develop -c just check` reached the existing `Cargo.toml` Taplo-format error; that file is unchanged by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MSRV checks to use `actix-server` version 2.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->